### PR TITLE
Clarify and simplify the integration tests setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,16 @@
   <description>Spring Boot - Cache Booster</description>
   <properties>
     <arquillian.version>1.4.0.Final</arquillian.version>
+    <awaitility.version>3.1.0</awaitility.version>
     <commons-logging.version>1.2</commons-logging.version>
     <junit.version>4.12</junit.version>
+    <openjdk18-openshift.version>1.3</openjdk18-openshift.version>
+    <rest-assured.version>3.1.0</rest-assured.version>
     <spring-boot-bom.version>1.5.14.Final</spring-boot-bom.version>
     <spring-boot.version>1.5.14.RELEASE</spring-boot.version>
-    <awaitility.version>1.7.0</awaitility.version>
-    <rest-assured.version>2.9.0</rest-assured.version>
-    <openjdk18-openshift.version>1.3</openjdk18-openshift.version>
-    <fabric8.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${openjdk18-openshift.version}</fabric8.generator.from>
+    <fabric8.generator.from>
+        registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${openjdk18-openshift.version}
+    </fabric8.generator.from>
   </properties>
   <licenses>
     <license>
@@ -54,31 +56,24 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+          <groupId>io.rest-assured</groupId>
+          <artifactId>rest-assured</artifactId>
+          <version>${rest-assured.version}</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.awaitility</groupId>
+          <artifactId>awaitility</artifactId>
+          <version>${awaitility.version}</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
           <version>${commons-logging.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>com.jayway.restassured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <version>${rest-assured.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.jayway.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>${awaitility.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
   <modules>
     <module>cute-name-service</module>
     <module>greeting-service</module>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
   <description>Spring Boot - Cache Booster</description>
   <properties>
     <arquillian.version>1.4.0.Final</arquillian.version>
+    <commons-logging.version>1.2</commons-logging.version>
     <junit.version>4.12</junit.version>
     <spring-boot-bom.version>1.5.14.Final</spring-boot-bom.version>
     <spring-boot.version>1.5.14.RELEASE</spring-boot.version>
@@ -51,6 +52,11 @@
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+          <version>${commons-logging.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,19 +53,16 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
           <groupId>io.rest-assured</groupId>
           <artifactId>rest-assured</artifactId>
           <version>${rest-assured.version}</version>
-          <scope>test</scope>
       </dependency>
       <dependency>
           <groupId>org.awaitility</groupId>
           <artifactId>awaitility</artifactId>
           <version>${awaitility.version}</version>
-          <scope>test</scope>
       </dependency>
       <dependency>
           <groupId>commons-logging</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -39,6 +39,24 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!--
         We need this because Apache httpclient depends on it
         but the import of the Spring Boot BOM excludes it

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -66,6 +66,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -39,15 +39,15 @@
             </exclusions>
         </dependency>
 
+        <!--
+        We need this because Apache httpclient depends on it
+        but the import of the Spring Boot BOM excludes it
+        (which makes sense for regular Spring Boot applications since they use jcl-over-slf4j,
+        but doesn't make sense for test artifacts like this one)
+        -->
         <dependency>
-            <groupId>io.openshift.booster</groupId>
-            <artifactId>spring-boot-cache-greeting</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.openshift.booster</groupId>
-            <artifactId>spring-boot-cache-cutename</artifactId>
-            <version>${project.version}</version>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
         </dependency>
     </dependencies>
 
@@ -91,38 +91,25 @@
                             <skip>false</skip>
                             <profile>aggregate</profile>
                         </configuration>
-                    </plugin>
-
-                    <!-- needed to be able to run the tests in an ephemeral namespace -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-resources-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy-image-streams</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>copy-resources</goal>
-                                </goals>
-                                <configuration>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <resources>
-                                        <resource>
-                                            <directory>${project.parent.basedir}/cute-name-service/target</directory>
-                                            <includes>
-                                                <include>*-is.yml</include>
-                                            </includes>
-                                        </resource>
-                                        <resource>
-                                            <directory>${project.parent.basedir}/greeting-service/target</directory>
-                                            <includes>
-                                                <include>*-is.yml</include>
-                                            </includes>
-                                        </resource>
-                                    </resources>
-                                </configuration>
-                            </execution>
-                        </executions>
+                        <dependencies>
+                            <!--
+                               We add the dependencies to the two modules that need to be deployed for the tests
+                               to run.
+                               This is done in order to make FMP pick up the generated Openshift
+                               resources file of each module and create an "uber" resources file containing
+                               resources for both modules (which is what the aggregate profile above does)
+                            -->
+                            <dependency>
+                                <groupId>io.openshift.booster</groupId>
+                                <artifactId>spring-boot-cache-greeting</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.openshift.booster</groupId>
+                                <artifactId>spring-boot-cache-cutename</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/tests/src/test/java/io/openshift/booster/OpenShiftIT.java
+++ b/tests/src/test/java/io/openshift/booster/OpenShiftIT.java
@@ -16,8 +16,8 @@
 
 package io.openshift.booster;
 
-import com.jayway.restassured.response.ExtractableResponse;
-import com.jayway.restassured.response.Response;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.arquillian.cube.openshift.impl.enricher.AwaitRoute;
 import org.arquillian.cube.openshift.impl.enricher.RouteURL;
 import org.jboss.arquillian.junit.Arquillian;
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 import java.net.URL;
 
-import static com.jayway.restassured.RestAssured.when;
+import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 


### PR DESCRIPTION
The integration tests themselves don't depend on the code of the modules
being tested.
They do however depend on those modules being deployed to Openshift.
In order for FMP to be able to deploy the modules, it needs to be able
to create an uber-resource Openshift file that contains the Openshift
definitions of both modules. That is done using the "aggregate" profile,
but assumes that FMP can find the resource file for each module on it's
classpath.
That is why the configuration has been changed to make the modules
dependencies of FMP instead of the tests themselves.