### PR TITLE
Remove unnecessary env var

### DIFF
--- a/greeting-service/.openshiftio/service.cache.yml
+++ b/greeting-service/.openshiftio/service.cache.yml
@@ -18,8 +18,6 @@ items:
         spec:
           containers:
             - env:
-              - name: DEFAULT_CACHE_EVICTION_MAX_ENTRIES
-                value: "10"
               - name: DEFAULT_CACHE_EXPIRATION_LIFESPAN
                 value: "10000"
               - name: INFINISPAN_CONNECTORS

--- a/service.cache.yml
+++ b/service.cache.yml
@@ -18,8 +18,6 @@ items:
         spec:
           containers:
             - env:
-              - name: DEFAULT_CACHE_EVICTION_MAX_ENTRIES
-                value: "10"
               - name: DEFAULT_CACHE_EXPIRATION_LIFESPAN
                 value: "10000"
               - name: INFINISPAN_CONNECTORS

--- a/tests/src/test/resources/test-cacheserver.yml
+++ b/tests/src/test/resources/test-cacheserver.yml
@@ -18,8 +18,6 @@ items:
         spec:
           containers:
             - env:
-              - name: DEFAULT_CACHE_EVICTION_MAX_ENTRIES
-                value: "10"
               - name: DEFAULT_CACHE_EXPIRATION_LIFESPAN
                 value: "10000"
               - name: INFINISPAN_CONNECTORS


### PR DESCRIPTION
This env var is also not part of the latest JBoss DataGrid so it's best
to remove it altogether